### PR TITLE
Add JSDOM theme toggle test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "bygog-lab",
+  "version": "1.0.0",
+  "description": "🧪 Bu proje, web geliştirme denemeleri yapabileceğiniz basit bir HTML laboratuvar ortamını hızlıca başlatmanızı sağlar.",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/tests/theme-toggle.test.js
+++ b/tests/theme-toggle.test.js
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment jsdom
+ */
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('theme toggle', () => {
+  let document;
+  let window;
+
+  beforeEach(() => {
+    const filePath = path.join(__dirname, '..', 'byGOG-Lab.html');
+    const html = fs.readFileSync(filePath, 'utf8');
+    const dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
+    document = dom.window.document;
+    window = dom.window;
+  });
+
+  test('body class and button text toggle', () => {
+    const button = document.getElementById('theme-toggle');
+    const body = document.body;
+
+    expect(body.classList.contains('koyu')).toBe(false);
+    expect(button.textContent).toBe('🌙');
+
+    button.click();
+
+    expect(body.classList.contains('koyu')).toBe(true);
+    expect(button.textContent).toBe('☀️');
+
+    button.click();
+
+    expect(body.classList.contains('koyu')).toBe(false);
+    expect(button.textContent).toBe('🌙');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest/JSDOM test covering theme-toggle button behavior
- set up package.json with Jest and jsdom dev deps and basic npm test script
- ignore node_modules in git

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68970f5e6c848331b37e7acaae88a8e7