### PR TITLE
Fix favicon reference and README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ Aşağıdaki komutları kullanarak laboratuvar sayfasını doğrudan tarayıcın
 
 ```powershell
 start https://raw.githack.com/byGOG/byGOG-Lab/main/byGOG-Lab.html
+```
+
+### Linux & macOS
+
+```bash
+xdg-open https://raw.githack.com/byGOG/byGOG-Lab/main/byGOG-Lab.html
+```

--- a/byGOG-Lab.html
+++ b/byGOG-Lab.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>byGOG</title>
-  <link rel="icon" type="image/x-icon" href="https://github.com/byGOG/byGOG-Lab/raw/main/svg/sdio.ico">
+  <link rel="icon" type="image/svg+xml" href="https://raw.githubusercontent.com/byGOG/byGOG-Lab/main/icon/Snappy.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Tektur:wght@400;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- fix broken favicon link in main HTML page
- close README code block and add Linux/macOS usage instructions

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68970a3551f48331a0db9bf8ef75a71d