### PR TITLE
Add meta description and Open Graph tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,11 @@
 <!DOCTYPE html>
 <html lang="tr">
-<head>
+  <head>
   <meta charset="UTF-8">
+  <meta name="description" content="Windows ve yazılım araçları için byGOG kaynak arşivi.">
+  <meta property="og:title" content="byGOG">
+  <meta property="og:description" content="Windows ve yazılım araçları için byGOG kaynak arşivi.">
+  <meta property="og:image" content="https://bygog.github.io/profil.jpg">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>byGOG</title>
   <link rel="icon" type="image/x-icon" href="https://github.com/byGOG/byGOG-Lab/raw/main/svg/sdio.ico">


### PR DESCRIPTION
## Summary
- add a description meta tag for search engines
- include Open Graph title, description, and image tags for richer link previews

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68984758f2a88331bcc6a78d30a81e95