### PR TITLE
Use system scheme when no theme is saved

### DIFF
--- a/index.html
+++ b/index.html
@@ -547,7 +547,10 @@
     });
     // Sayfa yüklenince tema uygula
     (function() {
-      const saved = localStorage.getItem('theme');
+      let saved = localStorage.getItem('theme');
+      if (!saved) {
+        saved = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'koyu' : 'aydinlik';
+      }
       setTheme(saved === 'koyu');
     })();
 


### PR DESCRIPTION
## Summary
- Fallback to system color scheme when no theme is stored in localStorage.

## Testing
- `node <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68987495950c833198e6e2b59c76363b