### PR TITLE
Fix missing OCCT name

### DIFF
--- a/links.json
+++ b/links.json
@@ -168,7 +168,7 @@
             },
             {
               "url": "https://www.ocbase.com/",
-              "name": "",
+              "name": "OCCT",
               "recommended": false,
               "description": "Sistem kararlılığı, stres testi ve donanım izleme aracı",
               "icon": "icon/occt.svg",


### PR DESCRIPTION
## Summary
- give OCCT link a visible name in links.json

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c57c80bf88331885d654d74d70731