### PR TITLE
Add Python to programming languages

### DIFF
--- a/links.json
+++ b/links.json
@@ -1365,6 +1365,15 @@
               "tags": []
             },
             {
+              "url": "https://www.python.org/",
+              "name": "Python",
+              "recommended": false,
+              "description": "Genel amaçlı, dinamik ve çok platformlu programlama dili",
+              "icon": "https://www.python.org/static/favicon.ico",
+              "alt": "Python",
+              "tags": []
+            },
+            {
               "url": "https://learn.microsoft.com/tr-tr/powershell/",
               "name": "PowerShell",
               "recommended": false,


### PR DESCRIPTION
## Summary
- include Python official site in programming languages & tools section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a04204bd8c8331a775862608fcb933