### PR TITLE
Use Firefox Relay SVG favicon

### DIFF
--- a/links.json
+++ b/links.json
@@ -612,7 +612,7 @@
               "name": "Firefox Relay",
               "recommended": false,
               "description": "E-posta gizliliği ve maskeleme servisi",
-              "icon": "https://relay.firefox.com/favicon.ico",
+              "icon": "https://relay.firefox.com/favicon.svg",
               "alt": "Firefox Relay",
               "tags": []
             }


### PR DESCRIPTION
## Summary
- replace Firefox Relay icon with its SVG favicon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a049a8c1b08331a55595ef2c3b7507