### PR TITLE
Update icon URLs for browser extensions

### DIFF
--- a/links.json
+++ b/links.json
@@ -877,7 +877,7 @@
               "name": "Buster (Captcha Solver)",
               "recommended": false,
               "description": "reCAPTCHA sesli doğrulama çözücü eklentisi",
-              "icon": "icon/GitHub.svg",
+              "icon": "https://raw.githubusercontent.com/dessant/buster/main/src/assets/icons/app/icon.svg",
               "alt": null,
               "tags": []
             },
@@ -886,7 +886,7 @@
               "name": "SponsorBlock",
               "recommended": false,
               "description": "YouTube sponsor ve gereksiz bölümleri otomatik atlayan eklenti",
-              "icon": "https://sponsor.ajay.app/LogoSponsorBlockSimple256px.svg",
+              "icon": "https://sponsor.ajay.app/favicon-32x32.png",
               "alt": null,
               "tags": []
             },
@@ -913,7 +913,7 @@
               "name": "Greasy Fork",
               "recommended": false,
               "description": "Kullanıcı scriptleri ve tarayıcı betikleri arşivi",
-              "icon": "https://greasyfork.org/favicon.ico",
+              "icon": "https://greasyfork.org/vite/assets/blacklogo16-DftkYuVe.png",
               "alt": "Greasy Fork",
               "tags": []
             }


### PR DESCRIPTION
## Summary
- use upstream icons for Buster, SponsorBlock and Greasy Fork links

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a04f366a30833187b9363d4f27c1e9