### PR TITLE
Update Waveform and DNS Speed Test icons

### DIFF
--- a/links.json
+++ b/links.json
@@ -927,7 +927,7 @@
               "name": "Waveform Bufferbloat Test",
               "recommended": false,
               "description": "Bufferbloat sorununu ve bağlantı gecikmesini ölçen test aracı",
-              "icon": "https://www.waveform.com/favicon.ico",
+              "icon": "https://www.waveform.com/cdn/shop/t/41/assets/favicon.ico",
               "alt": "Waveform Bufferbloat Test",
               "tags": []
             },
@@ -936,7 +936,7 @@
               "name": "DNS Speed Test",
               "recommended": false,
               "description": "DNS sağlayıcılarının hızını karşılaştıran test",
-              "icon": "https://dnsspeedtest.online/favicon.ico",
+              "icon": "https://dnsspeedtest.online/favicon/favicon-32x32.png",
               "alt": "DNS Speed Test",
               "tags": []
             }


### PR DESCRIPTION
## Summary
- use CDN favicon for Waveform Bufferbloat Test
- point DNS Speed Test icon to 32x32 PNG

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a050bfdcb0833194991470373ae93f