### PR TITLE
Use SourceForge SDIO icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <meta name="keywords" content="Windows, Office, yazılım, araçlar, güvenlik, byGOG">
   <meta name="author" content="byGOG">
   <title>byGOG</title>
-  <link rel="icon" type="image/x-icon" href="https://github.com/byGOG/byGOG-Lab/raw/main/svg/sdio.ico">
+  <link rel="icon" type="image/png" href="https://a.fsdn.com/allura/p/snappy-driver-installer-origin/icon.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Tektur:wght@400;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- switch favicon to Snappy Driver Installer Origin icon hosted on SourceForge

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a053e976e08331b3e92f7bc60bd46a