### PR TITLE
Add Immersive Translate to browser extension links

### DIFF
--- a/links.json
+++ b/links.json
@@ -916,6 +916,15 @@
               "icon": "https://greasyfork.org/vite/assets/blacklogo16-DftkYuVe.png",
               "alt": "Greasy Fork",
               "tags": []
+            },
+            {
+              "url": "https://immersivetranslate.com/",
+              "name": "Immersive Translate",
+              "recommended": false,
+              "description": "Web sayfalarını anında çeviren tarayıcı eklentisi.",
+              "icon": "https://immersivetranslate.com/favicon.ico",
+              "alt": "Immersive Translate",
+              "tags": []
             }
           ]
         },


### PR DESCRIPTION
## Summary
- add Immersive Translate browser extension link to the Tarayıcı Eklentileri & Güvenlik section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2ced8f9c0833180c690722132d11c