### PR TITLE
Add copy command for Office Tool Plus entry

### DIFF
--- a/links.json
+++ b/links.json
@@ -229,6 +229,7 @@
               "description": "Microsoft Office dağıtımı, kurulumu ve yönetimi için gelişmiş araç.",
               "icon": "icon/otp.svg",
               "alt": "Office Tool Plus",
+              "copyText": "irm https://officetool.plus | iex",
               "tags": []
             }
           ]


### PR DESCRIPTION
## Summary
- add the Office Tool Plus installation command to the office applications catalog entry so the copy button is available

## Testing
- npm run validate *(fails: existing data uses null alt values)*

------
https://chatgpt.com/codex/tasks/task_e_68d7a9ecc6e88331aebeb1a870453cb2