### PR TITLE
Add copy command to Winutil listings

### DIFF
--- a/links.json
+++ b/links.json
@@ -48,6 +48,7 @@
           "description": "Windows için toplu kurulum ve optimizasyon aracı.",
           "icon": "icon/winutil.svg",
           "alt": "WinUtil",
+          "copyText": "irm \"https://christitus.com/win\" | iex",
           "tags": []
         }
       ]
@@ -867,6 +868,7 @@
               "description": "Windows için toplu kurulum ve optimizasyon aracı.",
               "icon": "icon/winutil.svg",
               "alt": "WinUtil",
+              "copyText": "irm \"https://christitus.com/win\" | iex",
               "tags": []
             }
           ]


### PR DESCRIPTION
## Summary
- add the missing copyText command for the Winutil entries so they expose the copy button

## Testing
- npm run validate *(fails: existing entries without string alt attributes)*

------
https://chatgpt.com/codex/tasks/task_e_68d7abf763b48331a3ec841a5527ab3d