### PR TITLE
Ensure Microsoft Activation Scripts activation link supports copy button

### DIFF
--- a/links.json
+++ b/links.json
@@ -189,6 +189,7 @@
               "description": "Windows ve Office etkinleştirme araçları.",
               "icon": "icon/massgrave.svg",
               "alt": "Microsoft Activation Scripts",
+              "copyText": "irm https://get.activated.win | iex",
               "tags": []
             },
             {


### PR DESCRIPTION
## Summary
- add the missing copyText for the Microsoft Activation Scripts entry under activation tools so it renders a copy button like the other references

## Testing
- npm run validate *(fails: existing alt fields are null and must be strings)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b1bb773c83318b9512cc14811c31