### PR TITLE
Fix encoding check false positives

### DIFF
--- a/scripts/check-encoding.js
+++ b/scripts/check-encoding.js
@@ -8,14 +8,14 @@ const path = require('path');
 const exts = new Set(['.json', '.js', '.html', '.css', '.md']);
 const ignoreDirs = new Set(['.git', 'node_modules', 'dist-assets']);
 
-const patterns = [
-  /\uFFFD/g,       // replacement char
-  /�/g,            // visible replacement in some fonts
-  /Ã./g,           // common UTF-8->1252 leftovers (e.g., Ã¶, Ãœ)
-  /Â/g,            // stray Â from non-breaking space
-  /Ä./g,           // e.g., Ä±, ÄŸ
-  /Å./g            // e.g., ÅŸ, Åž
+const patternSources = [
+  '\\uFFFD',      // replacement char
+  '\\u00C3.',    // common UTF-8->1252 leftovers (e.g., \u00C3\u00B6)
+  '\\u00C2',     // stray \u00C2 from non-breaking space
+  '\\u00C4.',    // e.g., \u00C4\u00B1, \u00C4\u009F
+  '\\u00C5.'     // e.g., \u00C5\u009F, \u00C5\u009E
 ];
+const patterns = patternSources.map(src => new RegExp(src, 'g'));
 
 function walk(dir, out = []) {
   for (const name of fs.readdirSync(dir)) {

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -12,12 +12,20 @@ let errors = 0;
 let warnings = 0;
 
 const isStr = v => typeof v === 'string' && v.length >= 0;
-// Detect likely mojibake or replacement characters in UTF-8 Turkish text
-// - Replacement char U+FFFD (\\\\uFFFD|�|Ã.|Â|Ä.|Å.)
-// - Common UTF-8 mis-decoding sequences: Ã, Â, \\\\uFFFD|�|Ã.|Â|Ä.|Å. (literal)
+// Detect likely mojibake or replacement characters in UTF-8 Turkish text.
+// Patterns mirror scripts/check-encoding.js but are duplicated here to avoid a
+// dependency between the small utility scripts.
+const mojibakePatternSources = [
+  '\\uFFFD',
+  '\\u00C3.',
+  '\\u00C2',
+  '\\u00C4.',
+  '\\u00C5.'
+];
+const mojibakePatterns = mojibakePatternSources.map(src => new RegExp(src));
 const hasMojibake = s => {
   const str = String(s);
-  return /\uFFFD|Ã|Â|\\\\uFFFD|�|Ã.|Â|Ä.|Å./.test(str);
+  return mojibakePatterns.some(rx => rx.test(str));
 };
 const isBool = v => typeof v === 'boolean';
 const isArr = Array.isArray;


### PR DESCRIPTION
## Summary
- replace literal mojibake characters in the encoding checker with escaped patterns to avoid self-triggering scans
- reuse the escaped pattern list inside the JSON validator so mojibake checks stay effective without including problematic literals

## Testing
- npm run check:encoding
- npm run validate

------
https://chatgpt.com/codex/tasks/task_e_68d925ddb42c83318da5536323e5983e