### PR TITLE
Add copy command for IDM Activation Script

### DIFF
--- a/links.json
+++ b/links.json
@@ -204,7 +204,8 @@
               "description": "IDM için aktivasyon scripti.",
               "icon": "icon/powershell.svg",
               "alt": "IDM Activation Script",
-              "tags": []
+              "tags": [],
+              "copyText": "iex(irm is.gd/idm_reset)"
             }
           ]
         },


### PR DESCRIPTION
## Summary
- add the PowerShell activation snippet for the IDM Activation Script entry so the site renders a copy button for the command

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d93c3e4c548331909c2dfda35eff9b